### PR TITLE
Slight documentation restructuring and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,15 @@ and
 
 ```https://github.com/clarin-eric/LRSwitchboard-rest ```
 
-# Publications
+# [Publications](./publications)
 
 This directory holds the publications on the LR Switchboard.
 
-# Deliverables
+# [Deliverables](./deliverables)
 
 This directory holds project deliverables on the LR Switchboard.
 
-# Documentation (and other types)
+# [Documentation](./documentation) (and other types)
 
 This directory holds other documents on the switchboard.
-
 

--- a/documentation/Architecture.md
+++ b/documentation/Architecture.md
@@ -1,0 +1,6 @@
+# Language Resource Switchboard architecture
+
+## Components
+
+{TODO}
+Front end, back end service(s)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,9 @@
+# Language Resource Switchboard documentation
+
+## Design
+* [Architecture](Architecture.md): Switchboard architecture
+* [Use cases](https://docs.google.com/document/d/1LpkkJNevgpF1tLKHZpAukOdwiqo88N53jhD7Fw7CuBg): collection of use cases to (potentially) support (Google doc)
+
+## Implementation
+* [REST](Rest.md): back end REST service
+* [Piwik](Piwik.md): usage statistics via [Matomo](http://matomo.org/)

--- a/documentation/REST.md
+++ b/documentation/REST.md
@@ -1,0 +1,2 @@
+# Language Resource Switchboard REST documentation
+See https://github.com/clarin-eric/LRSwitchboard-rest/blob/master/index.html

--- a/documentation/UseCases.txt
+++ b/documentation/UseCases.txt
@@ -1,3 +1,0 @@
-Use cases for the LR Switchboard are currently compiled at:
-
-https://docs.google.com/document/d/1LpkkJNevgpF1tLKHZpAukOdwiqo88N53jhD7Fw7CuBg


### PR DESCRIPTION
I have added a README file for the documentation folder and added stubs for architecture and REST. See https://github.com/twagoo/LRSwitchboard-doc/tree/master/documentation